### PR TITLE
Generic Vapor Email API

### DIFF
--- a/Sources/Email/Application+Emails.swift
+++ b/Sources/Email/Application+Emails.swift
@@ -39,7 +39,7 @@ extension Application {
         
         public var client: EmailClient {
             guard let factory = self.storage.makeEmailClient else {
-                fatalError("EmailClient is not configured, please use: app.emails.use")
+                fatalError("EmailClient is not configured, use: app.emails.use()")
             }
             
             return factory(application)

--- a/Sources/Email/Emailable.swift
+++ b/Sources/Email/Emailable.swift
@@ -1,4 +1,3 @@
-// Perhaps protocol "Emailable" could be added to content that has a email field and optional name field?
 public protocol Emailable {
     static var emailKeyPath: KeyPath<Self, String> { get }
     static var nameKeyPath: KeyPath<Self, String?>? { get }


### PR DESCRIPTION
This PR serves as a discussion and W.I.P for this repository and the API.

## EmailClient
So far I've implemented `EmailClient` that providers must conform to, which allows to send a `VaporEmail`. 

## EmailAddress
You specify the sender and recipients with the `EmailAddress` type, which can be initialized by a string in the following formats:
- `"test@vapor.codes"` -> name: `nil`, email: `"test@vapor.codes"`
- `"Vapor <test@vapor.codes>`" -> name: `"Vapor"`, email: `"test@vapor.codes"`

## Emailable
Another thing I've added is a `Emailable` protocol, which can be added to a `User` for example and then you can do:
~~~~swift
let user: User  = ...
let email = VaporEmail(from: "test@test.com", to: user)
req.email.send(email)
~~~~